### PR TITLE
Changes to react-tools example

### DIFF
--- a/react-tools/README.md
+++ b/react-tools/README.md
@@ -5,3 +5,5 @@ First, install react-tools globally.
 Then run the watcher:
 
     $ jsx --watch src/ build/
+
+Then open helloworld.html in a web browser

--- a/react-tools/build/helloworld.js
+++ b/react-tools/build/helloworld.js
@@ -1,8 +1,6 @@
-require('react-tools');
-
 /** @jsx React.DOM */
+
 React.renderComponent(
-  <h1>Hello, world!</h1>,
+  React.DOM.h1(null, "Hello, world!"),
   document.getElementById('example')
 );
-

--- a/react-tools/helloworld.html
+++ b/react-tools/helloworld.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Hello React!</title>
+    <script src="http://fb.me/react-0.11.2.js"></script>
+  </head>
+  <body>
+    <div id="example"></div>
+    <script src="build/helloworld.js"></script>
+  </body>
+</html>

--- a/react-tools/src/helloworld.js
+++ b/react-tools/src/helloworld.js
@@ -1,8 +1,6 @@
-require('react-tools');
-
 /** @jsx React.DOM */
+
 React.renderComponent(
   <h1>Hello, world!</h1>,
   document.getElementById('example')
 );
-


### PR DESCRIPTION
More details are in the individual commits, but this
- Uses the correct syntax in src/helloworld.js
- Adds helloworld.html
- renames README.txt to README.md
